### PR TITLE
Add mdbook and CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,42 @@
+name: github pages
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.9"
+
+    - name: Install dependencies
+      run: pip install mdformat
+
+    - name: Run Format
+      run: mdformat . --check
+  deploy:
+    needs: format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v1
+        with:
+          mdbook-version: '0.4.9'
+
+      - run: mdbook build
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: github.ref == 'refs/heads/main'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./book

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.pre-commit-config.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.pre-commit-config.yaml
+book

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # Cabal User Guide
+
+## Dependencies
+
+All dependencies are provided via nix. This project is defined as a flake so you can use `nix develop` to enter a shell. There is also `flake-compat` setup so a regular `nix shell` should work as well!
+
+If you don't want to use nix you can install these dependencies by themselves. It should be noted that the pre-commit-hooks are setup using nix, so if you want to not use nix it might be convenient to setup your own commit hooks, or you can run mdformat on your own. CI will fail if markdown files are not correctly formatted!
+
+- [mdbook](https://rust-lang.github.io/mdBook/cli/index.html)
+- [mdformat](https://pypi.org/project/mdformat/)
+
+## Running Locally
+
+This project is built with mdbook and they have [great documentation](https://rust-lang.github.io/mdBook/index.html).
+
+The main command for development is `mdbook serve` which will run the book locally on `localhost:3000`.
+
+## Contributing
+
+Chapters can be edited in their corresponding markdown files (see [SUMMARY.md](./src/SUMMARY.md) for reference). To add a new chapter, add a link in SUMMARY.md and then create the corresponding markdown file. For more in depth instructions on adding content to an mdbook project see the [official docs](https://rust-lang.github.io/mdBook/format/summary.html)

--- a/book.toml
+++ b/book.toml
@@ -1,0 +1,12 @@
+[book]
+title = "Cabal User Guide"
+authors = ["Jonathan Lorimer"]
+description = "A user friendly guide on how to get up and running with Cabal"
+language = "en"
+multilingual = false
+src = "src"
+
+[output.html]
+git-repository-url = "https://github.com/haskell/cabal-userguide"
+git-repository-icon = "fa-github"
+edit-url-template = "https://github.com/haskell/cabal-userguide/edit/main/{path}"

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,9 @@
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  in fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+    sha256 = lock.nodes.flake-compat.locked.narHash; }
+) {
+  src =  ./.;
+}).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,109 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1606424373,
+        "narHash": "sha256-oq8d4//CJOrVj+EcOaSXvMebvuTkmBJuT5tzlfewUnQ=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "99f1c2157fba4bfe6211a321fd0ee43199025dbf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1623660459,
+        "narHash": "sha256-OTmOsh43po7r5F9s9H6lVCBQ2b0FikWbmiwLbMAGRdw=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "98c8d36b1828009b20f12544214683c7489935a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1619345332,
+        "narHash": "sha256-qHnQkEp1uklKTpx3MvKtY6xzgcqXDsz5nLilbbuL+3A=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "2ebf2558e5bf978c7fb8ea927dfaed8fefab2e28",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1623324058,
+        "narHash": "sha256-Jm9GUTXdjXz56gWDKy++EpFfjrBaxqXlLvTLfgEi8lo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "432fc2d9a67f92e05438dff5fdc2b39d33f77997",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1619531122,
+        "narHash": "sha256-ovm5bo6PkZzNKh2YGXbRKYIjega0EjiEP0YDwyeXEYU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bb80d578e8ad3cb5a607f468ac00cc546d0396dc",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1622650193,
+        "narHash": "sha256-qSzUpJDv04ajS9FXoCq6NjVF3qOt9IiGIiGh0P8amyw=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "0398f0649e0a741660ac5e8216760bae5cc78579",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,41 @@
+{
+  description = "Cabal User Guide";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
+    flake-utils.url = "github:numtide/flake-utils";
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+  };
+
+  outputs = { self, nixpkgs, pre-commit-hooks, flake-utils, flake-compat}:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = nixpkgs.legacyPackages.${system}; in
+      {
+        checks = {
+          pre-commit-check = pre-commit-hooks.lib.${system}.run {
+            src = ./.;
+            hooks = {
+              md-format = {
+                enable = true;
+                name = "Format Markdown";
+                entry = "${pkgs.python39Packages.mdformat}/bin";
+                files = "\\.md$";
+                language = "system";
+              };
+            };
+          };
+        };
+        devShell = pkgs.mkShell {
+          inherit (self.checks.${system}.pre-commit-check) shellHook;
+          buildInputs = with pkgs; [
+            mdbook
+            python39Packages.mdformat
+          ];
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
               md-format = {
                 enable = true;
                 name = "Format Markdown";
-                entry = "${pkgs.python39Packages.mdformat}/bin";
+                entry = "${pkgs.python39Packages.mdformat}/bin/mdformat";
                 files = "\\.md$";
                 language = "system";
               };

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,9 @@
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  in fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+    sha256 = lock.nodes.flake-compat.locked.narHash; }
+) {
+  src =  ./.;
+}).shellNix

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -1,0 +1,3 @@
+# Summary
+
+- [Chapter 1](./chapter_1.md)

--- a/src/chapter_1.md
+++ b/src/chapter_1.md
@@ -1,0 +1,1 @@
+# Chapter 1


### PR DESCRIPTION
In this PR I have 
- [x] added the `mdbook` and `mdformatter` dependencies via nix, while the setup uses nix flakes it also provides legacy shims with flakes-compat (so `nix-shell` should work)
- [x] initialized mdbook
- [x] updated the readme with getting started and non-nix instructions
- [x] update the readme with contributing guidelines
- [x] setup CI